### PR TITLE
Draft: Add softres.it export feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,126 +1,158 @@
-import React, { useEffect, useState } from 'react';
-import { HashRouter as Router, Link, Switch, Route, Redirect } from 'react-router-dom';
-import { checkLogin, fetchData, getPlayers } from './api/async';
-import { getInstanceData, getPlayer, prepareData } from './api';
-import PlayerList from './components/PlayerList';
-import PlayerDetails from './components/PlayerDetails';
-import BossList from './components/BossList';
-import ReservationsStart from './components/reservation/ReservationsStart';
-import { getBosses } from './api/loot';
-import { Instance, Player, PlayerName } from './types';
-import './App.css';
-import AdminReservations from './components/reservationAdmin/AdminReservations';
-import InvalidPlayerHandler from './components/InvalidPlayerHandler';
-import { instances } from './constants';
+import React, { useEffect, useState } from "react";
+import {
+  HashRouter as Router,
+  Link,
+  Switch,
+  Route,
+  Redirect,
+} from "react-router-dom";
+import { checkLogin, fetchData, getPlayers } from "./api/async";
+import { getInstanceData, getPlayer, prepareData } from "./api";
+import PlayerList from "./components/PlayerList";
+import PlayerDetails from "./components/PlayerDetails";
+import BossList from "./components/BossList";
+import ReservationsStart from "./components/reservation/ReservationsStart";
+import { getBosses } from "./api/loot";
+import { Instance, Player, PlayerName } from "./types";
+import "./App.css";
+import AdminReservations from "./components/reservationAdmin/AdminReservations";
+import InvalidPlayerHandler from "./components/InvalidPlayerHandler";
+import { instances } from "./constants";
+import SoftresExporter from "./components/SoftresExporter";
 
 function App() {
-    const [isLoaded, setIsLoaded] = useState(false);
-    const [error, setError] = useState<Error>();
-    const [loginPlayer, setLoginPlayer] = useState<Player | undefined>();
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [error, setError] = useState<Error>();
+  const [loginPlayer, setLoginPlayer] = useState<Player | undefined>();
 
-    let instance: Instance = 'tbc5';
+  let instance: Instance = "tbc5";
 
-    const pathParts = window.location.pathname.split('/');
-    const path = pathParts[pathParts.length - 1];
-    if (instances.includes(path as Instance)) {
-        instance = path as Instance;
-    } else {
-        console.warn('Path is not a valid instance', path, instances);
-    }
+  const pathParts = window.location.pathname.split("/");
+  const path = pathParts[pathParts.length - 1];
+  if (instances.includes(path as Instance)) {
+    instance = path as Instance;
+  } else {
+    console.warn("Path is not a valid instance", path, instances);
+  }
 
-    const instanceData = getInstanceData(instance);
+  const instanceData = getInstanceData(instance);
 
-    useEffect(() => {
-        document.title = `HH ${instanceData.name}`;
-        let loginPlayerName: PlayerName | undefined = undefined;
-        checkLogin()
-            .then((playerName: PlayerName | undefined) => {
-                loginPlayerName = playerName;
-            })
-            // TEMPORARY skip reservations unless logged in as admin until all members have made lists
-            .then(() => fetchData(instance, false)) // instance === 'tbc3' && !!loginPlayerName))
-            .then(() => prepareData())
-            .then(() => setIsLoaded(true))
-            .catch((error) => {
-                setError(error);
-                console.error(error);
-            })
-            .then(() => {
-                try {
-                    if (loginPlayerName) {
-                        setLoginPlayer(getPlayer(loginPlayerName));
-                    } else {
-                        setLoginPlayer(undefined);
-                    }
-                } catch (error) {
-                    setLoginPlayer(undefined);
-                    console.error(error);
-                }
-            })
-    }, [instance, instanceData]);
+  useEffect(() => {
+    document.title = `HH ${instanceData.name}`;
+    let loginPlayerName: PlayerName | undefined = undefined;
+    checkLogin()
+      .then((playerName: PlayerName | undefined) => {
+        loginPlayerName = playerName;
+      })
+      // TEMPORARY skip reservations unless logged in as admin until all members have made lists
+      .then(() => fetchData(instance, false)) // instance === 'tbc3' && !!loginPlayerName))
+      .then(() => prepareData())
+      .then(() => setIsLoaded(true))
+      .catch((error) => {
+        setError(error);
+        console.error(error);
+      })
+      .then(() => {
+        try {
+          if (loginPlayerName) {
+            setLoginPlayer(getPlayer(loginPlayerName));
+          } else {
+            setLoginPlayer(undefined);
+          }
+        } catch (error) {
+          setLoginPlayer(undefined);
+          console.error(error);
+        }
+      });
+  }, [instance, instanceData]);
 
-    return (
-        <Router>
-            <div className="App">
-                {isLoaded ? (
-                    <>
-                        <header>
-                            <img className="headerImage" src={`./${instanceData.image}`} alt={instanceData.name} />
-                            <h2 className="headerTitle">{instanceData.name}</h2>
-                            <a href="/">Held Hostile</a>
-                            {" - "}
-                            <Link to="/">Bosses</Link>
-                            {" - "}
-                            <Link to="/players">Players</Link>
-                            {" - "}
-                            <Link to="/reservations">Update reservations</Link>
-                            {loginPlayer === undefined ? (
-                                <>
-                                    <span style={{ color: '#555' }}>{" - "}</span>
-                                    <a href={`/Identity/Account/Login?ReturnUrl=%2F${instance}`} style={{ color: '#555' }}>Login</a>
-                                </>
-                            ) : (
-                                <>
-                                    {" - "}
-                                    <Link to="/reservations/admin">Admin</Link>
-                                </>
-                            )}
-                        </header>
-                        <Switch>
-                            <Route exact path="/">
-                                <BossList bosses={Object.values(getBosses(instance))} instance={instance} />
-                            </Route>
-                            <Route exact path="/players">
-                                <PlayerList instance={instance} players={Object.values(getPlayers())} />
-                            </Route>
-                            <Route path="/players/:playerName">
-                                <InvalidPlayerHandler path="/players" >
-                                    <PlayerDetails instance={instance} />
-                                </InvalidPlayerHandler>
-                            </Route>
-                            <Route path={"/reservations/admin/:playerName?/:entryId?"}>
-                                {loginPlayer ? (
-                                    <AdminReservations instance={instance} loginPlayer={loginPlayer} />
-                                ) : (
-                                    <Redirect to={"/"} />
-                                )}
-                            </Route>
-                            <Route path="/reservations">
-                                <ReservationsStart instance={instance} loginPlayer={loginPlayer} />
-                            </Route>
-                        </Switch>
-                    </>
-                ) : error ? (
-                    <>
-                        <p>Error fetching data!</p>
-                        <pre>{error.message}</pre>
-                    </>
-                ) :(
-                    <p>Loading..</p>
+  return (
+    <Router>
+      <div className="App">
+        {isLoaded ? (
+          <>
+            <header>
+              <img
+                className="headerImage"
+                src={`./${instanceData.image}`}
+                alt={instanceData.name}
+              />
+              <h2 className="headerTitle">{instanceData.name}</h2>
+              <a href="/">Held Hostile</a>
+              {" - "}
+              <Link to="/">Bosses</Link>
+              {" - "}
+              <Link to="/players">Players</Link>
+              {" - "}
+              <Link to="/reservations">Update reservations</Link>
+              {loginPlayer === undefined ? (
+                <>
+                  <span style={{ color: "#555" }}>{" - "}</span>
+                  <a
+                    href={`/Identity/Account/Login?ReturnUrl=%2F${instance}`}
+                    style={{ color: "#555" }}
+                  >
+                    Login
+                  </a>
+                </>
+              ) : (
+                <>
+                  {" - "}
+                  <Link to="/reservations/admin">Admin</Link>
+                </>
+              )}
+            </header>
+            <Switch>
+              <Route exact path="/">
+                <SoftresExporter
+                  players={Object.values(getPlayers())}
+                  bosses={Object.values(getBosses(instance))}
+                ></SoftresExporter>
+                <BossList
+                  bosses={Object.values(getBosses(instance))}
+                  instance={instance}
+                />
+              </Route>
+              <Route exact path="/players">
+                <PlayerList
+                  instance={instance}
+                  players={Object.values(getPlayers())}
+                />
+              </Route>
+              <Route path="/players/:playerName">
+                <InvalidPlayerHandler path="/players">
+                  <PlayerDetails instance={instance} />
+                </InvalidPlayerHandler>
+              </Route>
+              <Route path={"/reservations/admin/:playerName?/:entryId?"}>
+                {loginPlayer ? (
+                  <AdminReservations
+                    instance={instance}
+                    loginPlayer={loginPlayer}
+                  />
+                ) : (
+                  <Redirect to={"/"} />
                 )}
-            </div>
-        </Router>
-    );
+              </Route>
+              <Route path="/reservations">
+                <ReservationsStart
+                  instance={instance}
+                  loginPlayer={loginPlayer}
+                />
+              </Route>
+            </Switch>
+          </>
+        ) : error ? (
+          <>
+            <p>Error fetching data!</p>
+            <pre>{error.message}</pre>
+          </>
+        ) : (
+          <p>Loading..</p>
+        )}
+      </div>
+    </Router>
+  );
 }
 
 export default App;

--- a/src/components/SoftresExporter.tsx
+++ b/src/components/SoftresExporter.tsx
@@ -1,13 +1,7 @@
 import React, { useState } from "react";
-import {
-  Boss,
-  BossDrop,
-  Player,
-  SoftresitPlayerPayload,
-  SoftresitRaidPayload,
-  SoftresitRaidResponse,
-} from "../types";
+import { Boss, BossDrop, Player } from "../types";
 import axios from "axios";
+import { convertPlayerToPayload, createRaid } from "./softres.it/utilts";
 
 type SoftresExporterProps = { bosses: Boss[]; players: Player[] };
 
@@ -21,110 +15,79 @@ interface PlayerWithReserves {
   items: number[];
 }
 
+const nonReceived = (reservation: BossDrop["reservations"][number]): boolean =>
+  !reservation.entry.received;
+
+const hasReservation = (drop: BossDrop): boolean =>
+  drop.reservations.filter(nonReceived).length > 0;
+
+const createSoftresList = (
+  bosses: Boss[],
+  players: Player[]
+): PlayerWithReserves[] => {
+  // Get all boss drops as a list
+  const allBossDrops = bosses.map((boss) => boss.drops).flat();
+  // Produce list of drops with reserves that are not received
+  const dropsWithReserves = allBossDrops.filter(hasReservation);
+
+  // mutate the list to only extract reservations within roll range
+  const dropsWithContestingReserves: DropWithReserves[] = dropsWithReserves.map(
+    (drop) => {
+      const id = drop.item.id;
+      let reserves = drop.reservations
+        .filter(nonReceived)
+        .sort(
+          (a, b) =>
+            b.entry.calcualtedScore?.total! - a.entry.calcualtedScore?.total!
+        );
+      // ToDo:
+      // Before computing max we need to filter out any player that is not participating in the raid!
+      // This is a key feature as the roll ranges will not respect the actual participants otherwise.
+      const max = reserves[0].entry.calcualtedScore?.total!;
+      const reservingPlayers = reserves
+        .filter((res) => res.entry.calcualtedScore?.total! - max >= -3)
+        .map((reserve) => reserve.playerName);
+
+      return {
+        id,
+        players: reservingPlayers,
+      };
+    }
+  );
+
+  // Produce list of player names that have at least one contesting reserve
+  const playersWithContestingReserve = Array.from(
+    new Set(dropsWithContestingReserves.map((drop) => drop.players).flat())
+  );
+
+  // Produce list of players and their reserved ids
+  const playerNameWithReserves = playersWithContestingReserve.map(
+    (playerName) => ({
+      player: players.find((p) => p.name === playerName)!,
+      items: Array.from(
+        new Set(
+          dropsWithContestingReserves
+            .filter((drop) => drop.players.includes(playerName))
+            .map((drop) => drop.id)
+        )
+      ),
+    })
+  );
+
+  console.log(playerNameWithReserves);
+  return playerNameWithReserves;
+};
+
 const SoftresExporter = ({ bosses, players }: SoftresExporterProps) => {
   const [loading, setLoading] = useState(false);
   const [raidId, setRaidId] = useState<string>("");
   const [raidToken, setRaidToken] = useState<string>("");
 
-  const createSoftresList = (): PlayerWithReserves[] => {
-    const nonReceived = (
-      reservation: BossDrop["reservations"][number]
-    ): boolean => !reservation.entry.received;
-    const hasReservation = (drop: BossDrop): boolean =>
-      drop.reservations.filter(nonReceived).length > 0;
-
-    const allBossDrops = bosses.map((boss) => boss.drops).flat();
-    //   Produce list of drops with reserves that are not received
-    const dropsWithReserves = allBossDrops.filter(hasReservation);
-
-    // mutate the list to only extract reservations within roll range
-    const dropsWithContestingReserves: DropWithReserves[] =
-      dropsWithReserves.map((drop) => {
-        const id = drop.item.id;
-        let reserves = drop.reservations
-          .filter(nonReceived)
-          .sort(
-            (a, b) =>
-              b.entry.calcualtedScore?.total! - a.entry.calcualtedScore?.total!
-          );
-        const max = reserves[0].entry.calcualtedScore?.total!;
-        const reservingPlayers = reserves
-          .filter((res) => res.entry.calcualtedScore?.total! - max >= -3)
-          .map((reserve) => reserve.playerName);
-
-        return {
-          id,
-          players: reservingPlayers,
-        };
-      });
-
-    // Produce list of player names that have at least one contesting reserve
-    const playersWithContestingReserve = Array.from(
-      new Set(dropsWithContestingReserves.map((drop) => drop.players).flat())
-    );
-
-    // Produce list of players and their reserved ids
-    const playerNameWithReserves = playersWithContestingReserve.map(
-      (playerName) => ({
-        player: players.find((p) => p.name === playerName)!,
-        items: Array.from(
-          new Set(
-            dropsWithContestingReserves
-              .filter((drop) => drop.players.includes(playerName))
-              .map((drop) => drop.id)
-          )
-        ),
-      })
-    );
-
-    console.log(playerNameWithReserves);
-    return playerNameWithReserves;
-  };
-
-  const convertPlayerToPayload = (
-    playerWithReserves: PlayerWithReserves,
-    token: string
-  ): SoftresitPlayerPayload => {
-    const player = playerWithReserves.player;
-    const playerClass = player.class!.toLowerCase();
-    const className =
-      playerClass.charAt(0).toUpperCase() + playerClass.slice(1);
-
-    return {
-      token,
-      payload: {
-        class: className,
-        items: playerWithReserves.items,
-        name: player.name,
-      },
-    };
-  };
-
-  const createRaid = async (): Promise<SoftresitRaidResponse> => {
-    const payload: SoftresitRaidPayload = {
-      allowDuplicate: true,
-      amount: 10,
-      banned: [],
-      discord: false,
-      edition: "tbc",
-      faction: "Alliance",
-      hideReserves: false,
-      instance: "sunwellplateau",
-      itemLimit: 0,
-      plusModifier: 1,
-      restrictByClass: false,
-    };
-    const data = (
-      await axios.post(`https://softres.it/api/raid/create`, payload)
-    ).data as SoftresitRaidResponse;
-    return data;
-  };
-
   const addReservesToRaid = async () => {
     setLoading(true);
     const TTP = 400;
     const { raidId, token } = await createRaid();
-    const list = createSoftresList();
+    const list = createSoftresList(bosses, players);
     const playerPayloads = list.map((item) =>
       convertPlayerToPayload(item, token)
     );

--- a/src/components/SoftresExporter.tsx
+++ b/src/components/SoftresExporter.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { Boss, BossDrop, Player, SoftresitPlayerPayload } from "../types";
+import axios from "axios";
+
+type SoftresExporterProps = { bosses: Boss[]; players: Player[] };
+
+interface DropWithReserves {
+  id: number;
+  players: string[];
+}
+
+interface PlayerWithReserves {
+  player: Player;
+  items: number[];
+}
+
+const SoftresExporter = ({ bosses, players }: SoftresExporterProps) => {
+  const createSoftresList = (): PlayerWithReserves[] => {
+    const nonReceived = (
+      reservation: BossDrop["reservations"][number]
+    ): boolean => !reservation.entry.received;
+    const hasReservation = (drop: BossDrop): boolean =>
+      drop.reservations.filter(nonReceived).length > 0;
+
+    const allBossDrops = bosses.map((boss) => boss.drops).flat();
+    //   Produce list of drops with reserves that are not received
+    const dropsWithReserves = allBossDrops.filter(hasReservation);
+
+    // mutate the list to only extract reservations within roll range
+    const dropsWithContestingReserves: DropWithReserves[] =
+      dropsWithReserves.map((drop) => {
+        const id = drop.item.id;
+        let reserves = drop.reservations
+          .filter(nonReceived)
+          .sort(
+            (a, b) =>
+              b.entry.calcualtedScore?.total! - a.entry.calcualtedScore?.total!
+          );
+        const max = reserves[0].entry.calcualtedScore?.total!;
+        const reservingPlayers = reserves
+          .filter((res) => res.entry.calcualtedScore?.total! - max >= -3)
+          .map((reserve) => reserve.playerName);
+
+        return {
+          id,
+          players: reservingPlayers,
+        };
+      });
+
+    // Produce list of player names that have at least one contesting reserve
+    const playersWithContestingReserve = Array.from(
+      new Set(dropsWithContestingReserves.map((drop) => drop.players).flat())
+    );
+
+    // Produce list of players and their reserved ids
+    const playerNameWithReserves = playersWithContestingReserve.map(
+      (playerName) => ({
+        player: players.find((p) => p.name === playerName)!,
+        items: dropsWithContestingReserves
+          .filter((drop) => drop.players.includes(playerName))
+          .map((drop) => drop.id),
+      })
+    );
+
+    console.log(playerNameWithReserves);
+    return playerNameWithReserves;
+  };
+
+  const convertPlayerToPayload = (
+    playerWithReserves: PlayerWithReserves,
+    token: string
+  ): SoftresitPlayerPayload => {
+    const player = playerWithReserves.player;
+    const playerClass = player.class!.toLowerCase();
+    const className =
+      playerClass.charAt(0).toUpperCase() + playerClass.slice(1);
+
+    return {
+      token,
+      payload: {
+        class: className,
+        items: playerWithReserves.items,
+        name: player.name,
+      },
+    };
+  };
+
+  const addReservesToRaid = () => {
+    const list = createSoftresList();
+    // replace with id from recently created raid
+    const raidId = "";
+    // replace with token from recently created raid
+    const token = "";
+    const playerPayloads = list.map((item) =>
+      convertPlayerToPayload(item, token)
+    );
+
+    // This n
+    playerPayloads.forEach((payload, index) => {
+      setTimeout(() => {
+        const data = payload;
+        axios.post(`https://softres.it/api/raid/reserve/${raidId}`, data);
+      }, index * 250);
+    });
+  };
+
+  return <button onClick={addReservesToRaid}>Export to softres.it</button>;
+};
+
+export default SoftresExporter;

--- a/src/components/softres.it/utilts.ts
+++ b/src/components/softres.it/utilts.ts
@@ -1,0 +1,86 @@
+import axios from "axios";
+import { Player } from "../../types";
+
+// Softres.it payloads and responses
+
+export interface SoftresitRaidPayload {
+  allowDuplicate: boolean;
+  amount: number;
+  banned: number[];
+  discord: boolean;
+  edition: "tbc";
+  faction: "Alliance";
+  hideReserves: boolean;
+  instance: "sunwellplateau";
+  itemLimit: 0;
+  plusModifier: 1;
+  restrictByClass: boolean;
+}
+
+/**
+ * This response is considerably larger, but we only care about these two fields.
+ */
+export interface SoftresitRaidResponse {
+  raidId: string;
+  token: string;
+}
+
+export interface SoftresitPlayerPayload {
+  payload: {
+    class: string;
+    items: number[];
+    name: string;
+  };
+  token: string;
+}
+
+export interface DropWithReserves {
+  id: number;
+  players: string[];
+}
+
+export interface PlayerWithReserves {
+  player: Player;
+  items: number[];
+}
+
+/**
+ * Creates a raid using the softres.it api.
+ * Returns the created raid payload.
+ */
+export const createRaid = async (): Promise<SoftresitRaidResponse> => {
+  const payload: SoftresitRaidPayload = {
+    allowDuplicate: true,
+    amount: 10,
+    banned: [],
+    discord: false,
+    edition: "tbc",
+    faction: "Alliance",
+    hideReserves: false,
+    instance: "sunwellplateau",
+    itemLimit: 0,
+    plusModifier: 1,
+    restrictByClass: false,
+  };
+  const data = (await axios.post(`https://softres.it/api/raid/create`, payload))
+    .data as SoftresitRaidResponse;
+  return data;
+};
+
+export const convertPlayerToPayload = (
+  playerWithReserves: PlayerWithReserves,
+  token: string
+): SoftresitPlayerPayload => {
+  const player = playerWithReserves.player;
+  const playerClass = player.class!.toLowerCase();
+  const className = playerClass.charAt(0).toUpperCase() + playerClass.slice(1);
+
+  return {
+    token,
+    payload: {
+      class: className,
+      items: playerWithReserves.items,
+      name: player.name,
+    },
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,36 +108,3 @@ export interface EntryScore {
   attendance: number;
   total: number;
 }
-
-// Softres.it payloads and responses
-
-export interface SoftresitRaidPayload {
-  allowDuplicate: boolean;
-  amount: number;
-  banned: number[];
-  discord: boolean;
-  edition: "tbc";
-  faction: "Alliance";
-  hideReserves: boolean;
-  instance: "sunwellplateau";
-  itemLimit: 0;
-  plusModifier: 1;
-  restrictByClass: boolean;
-}
-
-/**
- * This response is considerably larger, but we only care about these two fields.
- */
-export interface SoftresitRaidResponse {
-  raidId: string;
-  token: string;
-}
-
-export interface SoftresitPlayerPayload {
-  payload: {
-    class: string;
-    items: number[];
-    name: string;
-  };
-  token: string;
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,82 +2,143 @@ import { Moment } from "moment";
 
 export type ItemScore = 100 | 90 | 80 | 70 | 65 | 60 | 55 | 54 | 53 | 52 | 10;
 
-export type Class = 'DRUID' | 'HUNTER' | 'MAGE' | 'PALADIN' | 'PRIEST' | 'ROGUE' | 'SHAMAN' | 'WARLOCK' | 'WARRIOR';
+export type CamelCasedClass =
+  | "Druid"
+  | "Hunter"
+  | "Mage"
+  | "Paladin"
+  | "Priest"
+  | "Rogue"
+  | "Shaman"
+  | "Warlock"
+  | "Warrior";
+
+export type Class =
+  | "DRUID"
+  | "HUNTER"
+  | "MAGE"
+  | "PALADIN"
+  | "PRIEST"
+  | "ROGUE"
+  | "SHAMAN"
+  | "WARLOCK"
+  | "WARRIOR";
 
 export type Date = string;
-export type GuildRank = 'Guild Master' | 'Officer' | 'Officer alt' | 'Member' | 'Initiate' | 'Social' | 'Alt';
+export type GuildRank =
+  | "Guild Master"
+  | "Officer"
+  | "Officer alt"
+  | "Member"
+  | "Initiate"
+  | "Social"
+  | "Alt";
 export type PlayerName = string;
-export type Instance = 'aq40' | 'naxx' | 'tbc1' | 'tbc2' | 'tbc3' | 'tbc5';
+export type Instance = "aq40" | "naxx" | "tbc1" | "tbc2" | "tbc3" | "tbc5";
 
 export interface InstanceData {
-    name: string,
-    image: string,
-    bonusRaidStartDate: Moment,
-    lootSheetID: string,
-    lootSheetTab: string,
-    itemScores: ItemScore[],
-    scoreGroupEdges: ItemScore[],
+  name: string;
+  image: string;
+  bonusRaidStartDate: Moment;
+  lootSheetID: string;
+  lootSheetTab: string;
+  itemScores: ItemScore[];
+  scoreGroupEdges: ItemScore[];
 }
 
 export interface Item {
-    name: string;
-    id: number;
-    restricted: boolean;
-    hidden: boolean;
-    icon?: string;
+  name: string;
+  id: number;
+  restricted: boolean;
+  hidden: boolean;
+  icon?: string;
 }
 
 export interface PlayerItemEntry {
-    item?: Item;
-    itemBonusEvents: string[];
-    score: ItemScore;
-    received?: Date;
-    calcualtedScore?: EntryScore;
+  item?: Item;
+  itemBonusEvents: string[];
+  score: ItemScore;
+  received?: Date;
+  calcualtedScore?: EntryScore;
 }
 
 export interface PlayerRaidEvent {
-    date: Date;
-    instanceName: string;
-    attendanceValue: number;
-    bonus?: {
-        value: number;
-    };
+  date: Date;
+  instanceName: string;
+  attendanceValue: number;
+  bonus?: {
+    value: number;
+  };
 }
 
 export interface Player {
-    name: PlayerName;
-    class?: Class;
-    guildRank?: GuildRank;
-    scoreSlots: PlayerItemEntry[];
-    attendedRaids: PlayerRaidEvent[];
-    calculatedAttendance?: number;
-    positionBonus?: number;
+  name: PlayerName;
+  class?: Class;
+  guildRank?: GuildRank;
+  scoreSlots: PlayerItemEntry[];
+  attendedRaids: PlayerRaidEvent[];
+  calculatedAttendance?: number;
+  positionBonus?: number;
 }
 
 export interface BossDrop {
-    item: Item;
-    groupedItems: Item[];
-    instance: Instance;
-    reservations: {
-        playerName: PlayerName;
-        entry: PlayerItemEntry;
-    }[];
-    freeLoot: {
-        playerName: PlayerName;
-        date: string;
-    }[];
+  item: Item;
+  groupedItems: Item[];
+  instance: Instance;
+  reservations: {
+    playerName: PlayerName;
+    entry: PlayerItemEntry;
+  }[];
+  freeLoot: {
+    playerName: PlayerName;
+    date: string;
+  }[];
 }
 
 export interface Boss {
-    name: string;
-    drops: BossDrop[];
-    index: number;
+  name: string;
+  drops: BossDrop[];
+  index: number;
 }
 
 export interface EntryScore {
-    base: number;
-    position: number;
-    item: number;
-    attendance: number;
-    total: number;
+  base: number;
+  position: number;
+  item: number;
+  attendance: number;
+  total: number;
+}
+
+// Softres.it payloads and responses
+
+export interface SoftresitRaidPayload {
+  allowDuplicate: boolean;
+  amount: number;
+  banned: number[];
+  characterNotes: boolean;
+  discord: boolean;
+  edition: "tbc";
+  faction: "Alliance";
+  hideReserves: boolean;
+  instance: "sunwellplateau";
+  itemLimit: 0;
+  plusModifier: 1;
+  restrictByClass: boolean;
+}
+
+/**
+ * This response is considerably larger, but we only care about these two fields.
+ */
+export interface SoftresitRaidResponse {
+  raidId: string;
+  token: string;
+}
+
+export interface SoftresitPlayerPayload {
+  payload: {
+    class: string;
+    items: number[];
+    name: string;
+  };
+  token: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,7 +115,6 @@ export interface SoftresitRaidPayload {
   allowDuplicate: boolean;
   amount: number;
   banned: number[];
-  characterNotes: boolean;
   discord: boolean;
   edition: "tbc";
   faction: "Alliance";


### PR DESCRIPTION
This adds an export button at the top of the page that goes through these steps. It currently lalcks one _crucial_ feature - it does not allow for filtering out players somehow. This will be required to remove players that will not attend the specific raid. This could be added by a simple list of checkboxes that can appear when requesting an export, as a prestep to the current raid creation.

## Ready
<img width="725" alt="Screenshot 2022-08-29 at 22 34 35" src="https://user-images.githubusercontent.com/5012939/187293838-a639cc96-afd8-4d58-904a-c994d8cb7180.png">

## Loading
<img width="702" alt="Screenshot 2022-08-29 at 22 34 39" src="https://user-images.githubusercontent.com/5012939/187293841-df0dc093-9da2-44a0-bdb0-7fda28148a08.png">

## Done
<img width="712" alt="Screenshot 2022-08-29 at 22 34 48" src="https://user-images.githubusercontent.com/5012939/187293847-58c6287e-9a16-426b-8bec-75a65d5206ed.png">
